### PR TITLE
feat: add DIDNostr, profile, and follows terms

### DIFF
--- a/context.jsonld
+++ b/context.jsonld
@@ -7,9 +7,19 @@
     "xsd": "http://www.w3.org/2001/XMLSchema#",
     "terms": "http://www.w3.org/2003/06/sw-vocab-status/ns#",
     "nostr": "https://w3id.org/nostr#",
+    "DIDNostr": "nostr:DIDNostr",
     "Event": "nostr:Event",
     "Relay": "nostr:Relay",
     "Person": "nostr:Person",
+    "profile": {
+      "@id": "nostr:profile",
+      "@type": "@id"
+    },
+    "follows": {
+      "@id": "nostr:follows",
+      "@type": "@id",
+      "@container": "@set"
+    },
     "pubkey": {
       "@id": "nostr:pubkey",
       "@type": "xsd:string"

--- a/index.html
+++ b/index.html
@@ -84,6 +84,13 @@
             "term_status": "stable"
           },
           {
+            "@id": "nostr:DIDNostr",
+            "@type": "rdfs:Class",
+            "comment": "A Nostr DID Document type.",
+            "label": "DIDNostr",
+            "term_status": "stable"
+          },
+          {
             "@id": "nostr:pubkey",
             "@type": ["rdfs:Property"],
             "comment": "Nostr pubkey 64 char lower case hex.",
@@ -272,6 +279,38 @@
             "label": "banner",
             "range": {
               "@id": "xsd:anyURI"
+            },
+            "term_status": "stable"
+          },
+          {
+            "@id": "nostr:profile",
+            "@type": ["rdfs:Property"],
+            "comment": "Profile metadata from kind 0 event.",
+            "domain": {
+              "@id": "nostr:DIDNostr"
+            },
+            "isDefinedBy": {
+              "@id": "nostr:"
+            },
+            "label": "profile",
+            "range": {
+              "@id": "owl:Thing"
+            },
+            "term_status": "stable"
+          },
+          {
+            "@id": "nostr:follows",
+            "@type": ["rdfs:Property"],
+            "comment": "Array of followed pubkeys from kind 3 event.",
+            "domain": {
+              "@id": "nostr:DIDNostr"
+            },
+            "isDefinedBy": {
+              "@id": "nostr:"
+            },
+            "label": "follows",
+            "range": {
+              "@id": "owl:Thing"
             },
             "term_status": "stable"
           }

--- a/vocab.json
+++ b/vocab.json
@@ -74,6 +74,13 @@
       "term_status": "stable"
     },
     {
+      "@id": "nostr:DIDNostr",
+      "@type": "rdfs:Class",
+      "comment": "A Nostr DID Document type.",
+      "label": "DIDNostr",
+      "term_status": "stable"
+    },
+    {
       "@id": "nostr:pubkey",
       "@type": [
         "rdfs:Property"
@@ -286,6 +293,42 @@
       "label": "banner",
       "range": {
         "@id": "xsd:anyURI"
+      },
+      "term_status": "stable"
+    },
+    {
+      "@id": "nostr:profile",
+      "@type": [
+        "rdfs:Property"
+      ],
+      "comment": "Profile metadata from kind 0 event.",
+      "domain": {
+        "@id": "nostr:DIDNostr"
+      },
+      "isDefinedBy": {
+        "@id": "nostr:"
+      },
+      "label": "profile",
+      "range": {
+        "@id": "owl:Thing"
+      },
+      "term_status": "stable"
+    },
+    {
+      "@id": "nostr:follows",
+      "@type": [
+        "rdfs:Property"
+      ],
+      "comment": "Array of followed pubkeys from kind 3 event.",
+      "domain": {
+        "@id": "nostr:DIDNostr"
+      },
+      "isDefinedBy": {
+        "@id": "nostr:"
+      },
+      "label": "follows",
+      "range": {
+        "@id": "owl:Thing"
       },
       "term_status": "stable"
     }

--- a/vocab.jsonld
+++ b/vocab.jsonld
@@ -74,6 +74,13 @@
       "term_status": "stable"
     },
     {
+      "@id": "nostr:DIDNostr",
+      "@type": "rdfs:Class",
+      "comment": "A Nostr DID Document type.",
+      "label": "DIDNostr",
+      "term_status": "stable"
+    },
+    {
       "@id": "nostr:pubkey",
       "@type": [
         "rdfs:Property"
@@ -286,6 +293,42 @@
       "label": "banner",
       "range": {
         "@id": "xsd:anyURI"
+      },
+      "term_status": "stable"
+    },
+    {
+      "@id": "nostr:profile",
+      "@type": [
+        "rdfs:Property"
+      ],
+      "comment": "Profile metadata from kind 0 event.",
+      "domain": {
+        "@id": "nostr:DIDNostr"
+      },
+      "isDefinedBy": {
+        "@id": "nostr:"
+      },
+      "label": "profile",
+      "range": {
+        "@id": "owl:Thing"
+      },
+      "term_status": "stable"
+    },
+    {
+      "@id": "nostr:follows",
+      "@type": [
+        "rdfs:Property"
+      ],
+      "comment": "Array of followed pubkeys from kind 3 event.",
+      "domain": {
+        "@id": "nostr:DIDNostr"
+      },
+      "isDefinedBy": {
+        "@id": "nostr:"
+      },
+      "label": "follows",
+      "range": {
+        "@id": "owl:Thing"
       },
       "term_status": "stable"
     }


### PR DESCRIPTION
## Summary

Adds missing terms required by the did:nostr specification to the Nostr JSON-LD context.

## Changes

Added to `context.jsonld`:
- **`DIDNostr`** - Type for Nostr DID documents
- **`profile`** - Field for profile metadata (`@type: @id`)
- **`follows`** - Array for social graph (`@type: @id`, `@container: @set`)

## Testing

After merge, verify at: https://w3id.org/nostr/context

Closes #10
Related: nostrcg/did-nostr#68