### PR TITLE
Define `nip05` and `lud16` profile terms

### DIFF
--- a/context.jsonld
+++ b/context.jsonld
@@ -68,6 +68,14 @@
       "@id": "nostr:banner",
       "@type": "xsd:anyURI"
     },
+    "nip05": {
+      "@id": "nostr:nip05",
+      "@type": "xsd:string"
+    },
+    "lud16": {
+      "@id": "nostr:lud16",
+      "@type": "xsd:string"
+    },
     "Ontology": "owl:Ontology",
     "Class": "rdfs:Class",
     "ObjectProperty": "owl:ObjectProperty",

--- a/index.html
+++ b/index.html
@@ -283,6 +283,38 @@
             "term_status": "stable"
           },
           {
+            "@id": "nostr:nip05",
+            "@type": ["rdfs:Property"],
+            "comment": "NIP-05 DNS-based internet identifier (e.g. name@example.com).",
+            "domain": {
+              "@id": "nostr:Person"
+            },
+            "isDefinedBy": {
+              "@id": "nostr:"
+            },
+            "label": "nip05",
+            "range": {
+              "@id": "xsd:string"
+            },
+            "term_status": "stable"
+          },
+          {
+            "@id": "nostr:lud16",
+            "@type": ["rdfs:Property"],
+            "comment": "LUD-16 Lightning address (e.g. name@getalby.com).",
+            "domain": {
+              "@id": "nostr:Person"
+            },
+            "isDefinedBy": {
+              "@id": "nostr:"
+            },
+            "label": "lud16",
+            "range": {
+              "@id": "xsd:string"
+            },
+            "term_status": "stable"
+          },
+          {
             "@id": "nostr:profile",
             "@type": ["rdfs:Property"],
             "comment": "Profile metadata from kind 0 event.",

--- a/vocab.json
+++ b/vocab.json
@@ -297,6 +297,42 @@
       "term_status": "stable"
     },
     {
+      "@id": "nostr:nip05",
+      "@type": [
+        "rdfs:Property"
+      ],
+      "comment": "NIP-05 DNS-based internet identifier (e.g. name@example.com).",
+      "domain": {
+        "@id": "nostr:Person"
+      },
+      "isDefinedBy": {
+        "@id": "nostr:"
+      },
+      "label": "nip05",
+      "range": {
+        "@id": "xsd:string"
+      },
+      "term_status": "stable"
+    },
+    {
+      "@id": "nostr:lud16",
+      "@type": [
+        "rdfs:Property"
+      ],
+      "comment": "LUD-16 Lightning address (e.g. name@getalby.com).",
+      "domain": {
+        "@id": "nostr:Person"
+      },
+      "isDefinedBy": {
+        "@id": "nostr:"
+      },
+      "label": "lud16",
+      "range": {
+        "@id": "xsd:string"
+      },
+      "term_status": "stable"
+    },
+    {
       "@id": "nostr:profile",
       "@type": [
         "rdfs:Property"

--- a/vocab.jsonld
+++ b/vocab.jsonld
@@ -297,6 +297,42 @@
       "term_status": "stable"
     },
     {
+      "@id": "nostr:nip05",
+      "@type": [
+        "rdfs:Property"
+      ],
+      "comment": "NIP-05 DNS-based internet identifier (e.g. name@example.com).",
+      "domain": {
+        "@id": "nostr:Person"
+      },
+      "isDefinedBy": {
+        "@id": "nostr:"
+      },
+      "label": "nip05",
+      "range": {
+        "@id": "xsd:string"
+      },
+      "term_status": "stable"
+    },
+    {
+      "@id": "nostr:lud16",
+      "@type": [
+        "rdfs:Property"
+      ],
+      "comment": "LUD-16 Lightning address (e.g. name@getalby.com).",
+      "domain": {
+        "@id": "nostr:Person"
+      },
+      "isDefinedBy": {
+        "@id": "nostr:"
+      },
+      "label": "lud16",
+      "range": {
+        "@id": "xsd:string"
+      },
+      "term_status": "stable"
+    },
+    {
       "@id": "nostr:profile",
       "@type": [
         "rdfs:Property"


### PR DESCRIPTION
Adds the two undefined profile terms surfaced by the did:nostr terms audit (nostrcg/did-nostr#68, nostrcg/did-nostr#93):

- **`nip05`** → `nostr:nip05` — NIP-05 DNS-based internet identifier (e.g. `name@example.com`)
- **`lud16`** → `nostr:lud16` — LUD-16 Lightning address (e.g. `name@getalby.com`)

Both are canonical Nostr/Lightning profile fields with no existing vocabulary home. Added as `xsd:string` properties on `nostr:Person`, mirroring the existing profile fields (`name`, `about`, `website`, etc.).

## Files

The vocabulary is stored in four synced places; all updated to keep them consistent:

- `context.jsonld` — term → IRI mappings
- `vocab.jsonld` — vocabulary definitions (`@graph`)
- `vocab.json` — byte-identical copy of `vocab.jsonld`
- `index.html` — embedded `@graph` for the rendered vocab page

Verified: all four parse as valid JSON, `vocab.json` stays byte-identical to `vocab.jsonld`, and the `index.html` embed matches the `vocab.jsonld` `@graph`.

## Scope

Two terms only, the slam-dunks. Still open from the audit, tracked separately:

- `FollowsEndpoint` — needs a design decision (add vs. drop in favor of `Relay`)
- `profile.timestamp` → `created_at` — a rename in the spec + test vectors, not a context change

Once this merges, the did:nostr profile DID documents expand cleanly for `nip05`/`lud16`.

Refs nostrcg/did-nostr#68, nostrcg/did-nostr#93